### PR TITLE
remove credentials form log

### DIFF
--- a/curl.ts
+++ b/curl.ts
@@ -109,7 +109,16 @@ export const curl = async (request: Request) => {
   }
 
   try {
-    console.log({ targetUrl, options });
+    // Log request without exposing credentials
+    const safeOptions = {
+      ...options,
+      headers: Object.fromEntries(
+        Object.entries(options.headers).map(([key, value]) =>
+          key.toLowerCase() === 'authorization' ? [key, '[REDACTED]'] : [key, value]
+        )
+      )
+    };
+    console.log({ targetUrl, options: safeOptions });
     // Make the actual request
     const response = await fetch(targetUrl, options as RequestInit);
 


### PR DESCRIPTION
So you were accidentally logging users' credentials. It would be nice if this didn't happen. Also, it would be nice if you specified a license. Up to you though. Consider these lines I added CC0, just for you, so you can still choose any license.