### PR TITLE
Add body parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,21 @@ NB: {url} uses the `https` protocol by default.
 
 #### Supported Query Parameters
 
-| Parameter        | Type             | Description                                                                                              | Example                                       |
-| ---------------- | ---------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `request`        | string           | Specifies the HTTP method. Valid values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`.     | `request=POST`                                |
-| `header`         | array of strings | Adds custom HTTP headers. Repeat for multiple headers.                                                   | `header=Content-Type:application/json`        |
-| `data`           | array of strings | Sends data in the request body (POST) or query string (with `get=true`). Repeat for multiple data pairs. | `data=key=value`                              |
-| `data-urlencode` | array of strings | Sends URL-encoded data in the request.                                                                   | `data-urlencode=comment=this%20is%20awesome`  |
-| `get`            | boolean          | Forces data to be sent as a GET request query string.                                                    | `get=true`                                    |
-| `include`        | boolean          | Includes response headers in the output.                                                                 | `include=true`                                |
-| `head`           | boolean          | Sends a HEAD request.                                                                                    | `head=true`                                   |
-| `user`           | string           | Specifies credentials for authentication (format: `username:password`).                                  | `user=user:pass`                              |
-| `location`       | boolean          | Follows HTTP redirects.                                                                                  | `location=true`                               |
-| `verbose`        | boolean          | Enables verbose output for debugging.                                                                    | `verbose=true`                                |
-| `access_token`   | string           | Injects an OAuth token for X or GitHub authentication.                                                   | `access_token=xyz`                            |
-| `instructions`   | string           | Specifies contextual instructions for the request.                                                       | `instructions=transform_response_to_markdown` |
+| Parameter        | Type             | Description                                                                                                                          | Example                                       |
+| ---------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| `request`        | string           | Specifies the HTTP method. Valid values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`.                                 | `request=POST`                                |
+| `header`         | array of strings | Adds custom HTTP headers. Repeat for multiple headers.                                                                               | `header=Content-Type:application/json`        |
+| `data`           | array of strings | Sends data in the request body (POST) or query string (with `get=true` or `body` parameter present). Repeat for multiple data pairs. | `data=key=value`                              |
+| `data-urlencode` | array of strings | Sends URL-encoded data in the request.                                                                                               | `data-urlencode=comment=this%20is%20awesome`  |
+| `body`           | string           | Sends raw body data in the request. Takes precedence over form data.                                                                 | `body={"key":"value"}`                        |
+| `get`            | boolean          | Forces data to be sent as a GET request query string.                                                                                | `get=true`                                    |
+| `include`        | boolean          | Includes response headers in the output.                                                                                             | `include=true`                                |
+| `head`           | boolean          | Sends a HEAD request.                                                                                                                | `head=true`                                   |
+| `user`           | string           | Specifies credentials for authentication (format: `username:password`).                                                              | `user=user:pass`                              |
+| `location`       | boolean          | Follows HTTP redirects.                                                                                                              | `location=true`                               |
+| `verbose`        | boolean          | Enables verbose output for debugging.                                                                                                | `verbose=true`                                |
+| `access_token`   | string           | Injects an OAuth token for X or GitHub authentication.                                                                               | `access_token=xyz`                            |
+| `instructions`   | string           | Specifies contextual instructions for the request.                                                                                   | `instructions=transform_response_to_markdown` |
 
 # Links
 

--- a/curl.ts
+++ b/curl.ts
@@ -67,8 +67,8 @@ export const curl = async (request: Request) => {
       if (key) formData.append(key, decodeURIComponent(value || ""));
     });
 
-    // If GET is forced or if it's a GET request
-    if (params.get("get") === "true" || options.method === "GET") {
+    // If GET is forced, there is a body or if it's a GET request
+    if (params.get("get") === "true" || params.has("body") || options.method === "GET") {
       // Append form data to URL as query string
       const searchParams = new URLSearchParams();
       formData.forEach((value, key) => {
@@ -88,6 +88,13 @@ export const curl = async (request: Request) => {
       options.body = formData;
     }
   }
+
+  // Handle request body data
+  if (params.has("body")) {
+    // Handle raw body data (takes precedence over form data)
+    const bodyData = params.get("body");
+  }
+
 
   // Force HEAD method if specified
   if (params.get("head") === "true") {

--- a/openapi.json
+++ b/openapi.json
@@ -68,7 +68,7 @@
           {
             "name": "data",
             "in": "query",
-            "description": "Sends data in the request body (POST) or query string (with get=true). Repeat for multiple data pairs.",
+            "description": "Sends data in the request body (POST) or query string (with get=true or body parameter present). Repeat for multiple data pairs.",
             "required": false,
             "schema": {
               "type": "array",
@@ -188,6 +188,15 @@
             "name": "template_id",
             "in": "query",
             "description": "Applies a predefined template of parameters.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "body",
+            "in": "query",
+            "description": "Sends raw body data in the request. Takes precedence over form data.",
             "required": false,
             "schema": {
               "type": "string"


### PR DESCRIPTION
Previously, you couldn't POST to an MCP server, because you have to send JSON data in the body. Now, I've added a body query parameter so that you can now use HTTP MCP servers with this.